### PR TITLE
Removed redundancy of mode indicator

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -18,6 +18,7 @@ set nowrap
 set t_Co=256
 set t_ut=
 set mouse=a
+set noshowmode
 
 let mapleader=","
 


### PR DESCRIPTION
The statusline already indicates the mode. No use for the default mode indicator anymore.